### PR TITLE
Remove patch metadata

### DIFF
--- a/bionic/debian/patches
+++ b/bionic/debian/patches
@@ -1,1 +1,0 @@
-../../ubuntu/debian/patches/

--- a/focal/debian/patches
+++ b/focal/debian/patches
@@ -1,1 +1,0 @@
-../../ubuntu/debian/patches/

--- a/ubuntu/debian/patches/series
+++ b/ubuntu/debian/patches/series
@@ -1,1 +1,0 @@
-0001_arm_test.patch


### PR DESCRIPTION
The contents of the patch were already removed by direct commits to `master`. This removes the empty files.

Closes #2.